### PR TITLE
Made paths more generic

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,13 +2,11 @@ require: rubocop-rspec
 AllCops:
   TargetRubyVersion: 2.4
   Exclude:
-  - 'lib/review_app_seeder.rb'
   - 'db/**/*'
   - 'tmp/**/*'
   - 'vendor/**/*'
   - 'bin/**/*'
   - 'log/**/*'
-  - 'spec/support/materialize_select_helper.rb'
 
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
@@ -32,11 +30,12 @@ Metrics/BlockLength:
   Exclude:
   - 'spec/**/*'
   - 'config/routes.rb'
-  - 'config/environments/production.rb'
+  - 'config/environments/*'
 
 Metrics/LineLength:
   Max: 120
   Exclude:
+  - 'spec/spec_helper.rb'
   - 'spec/rails_helper.rb'
   - 'config/initializers/*'
 
@@ -63,7 +62,6 @@ RSpec/NamedSubject:
 
 RSpec/NestedGroups:
   Enabled: false
-
 
 Style/BlockDelimiters:
   Enabled: false


### PR DESCRIPTION
There are a couple of project-specific paths in .rubocop.yml at the moment, and there are also a few cases where we can include a few similar files as well.

I'd suggest adding a comment at the top of `lib/review_app_seeder.rb` and `spec/support/materialize_select_helper.rb` to disable rubocop.