### PR TITLE
Enforces braces around functional blocks where the primary purpose of…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,7 +64,7 @@ RSpec/NestedGroups:
   Enabled: false
 
 Style/BlockDelimiters:
-  Enabled: false
+  EnforcedStyle: semantic
 
 Style/ClassAndModuleChildren:
   Enabled: false


### PR DESCRIPTION
… the block is to return a value

From the docs:
```
    # The `semantic` style enforces braces around functional blocks, where the
    # primary purpose of the block is to return a value and do..end for
    # procedural blocks, where the primary purpose of the block is its
    # side-effects.
    #
    # This looks at the usage of a block's method to determine its type (e.g. is
    # the result of a `map` assigned to a variable or passed to another
    # method) but exceptions are permitted in the `ProceduralMethods`,
    ...
```