### PR TITLE
Made the default block style "semantic"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,7 +64,7 @@ RSpec/NestedGroups:
   Enabled: false
 
 Style/BlockDelimiters:
-  Enabled: false
+  EnforcedStyle: semantic
 
 Style/ClassAndModuleChildren:
   Enabled: false


### PR DESCRIPTION
This tells rubocop to use ["jim weirich" style](http://www.virtuouscode.com/2011/07/26/the-procedurefunction-block-convention-in-ruby/) for blocks, where code blocks that return something should use braces but blocks with side-effects should use do/end