### PR TITLE
Don't omit braces when every argument is a hash

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,6 +66,9 @@ RSpec/NestedGroups:
 Style/BlockDelimiters:
   Enabled: false
 
+Style/BracesAroundHashParameters:
+  EnforcedStyle: context_dependent
+
 Style/ClassAndModuleChildren:
   Enabled: false
 


### PR DESCRIPTION
I'm seeing rubocop warnings like this

    spec/importers/snomed_importer_spec.rb:10:55: C: Style/BracesAroundHashParameters: Redundant curly braces around a hash parameter.
          }.to yield_successive_args({ 'name' => 'foo' }, { 'name' => 'bar' })

What rubocop is saying is that we should omit the braces around the last argument, but not the first one. To me that would look odd. However, rubocop has an `context_dependent` option for this cop that handles this case, and doesn't report it as an error, and I suggest we should use that.