### PR TITLE
Special cases for feature specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,13 +49,16 @@ Rails/FilePath:
   Enabled: false
 
 RSpec/DescribeClass:
-  Enabled: false
+  Exclude:
+  - 'spec/features/**/*'
 
 RSpec/ExampleLength:
-  Enabled: false
+  Exclude:
+  - 'spec/features/**/*'
 
 RSpec/MultipleExpectations:
-  Enabled: false
+  Exclude:
+  - 'spec/features/**/*'
 
 RSpec/NamedSubject:
   Enabled: false


### PR DESCRIPTION
At the moment we're disabling three rspec cops, which I think are useful:

* RSpec/DescribeClass (Check that the first argument to the top level describe is a constant)
* RSpec/ExampleLength (Checks for long examples)
* RSpec/MultipleExpectations (Checks if examples contain too many `expect` calls)

I suspect we only really want to disable these in feature specs, so I've changed the config so they ignore feature specs but work everywhere else instead.