### PR TITLE
Removed invalid cop from config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,9 +14,6 @@ Layout/AlignParameters:
 Layout/MultilineMethodCallIndentation:
   Enabled: false
 
-LetSetup:
-  Enabled: false
-
 Lint/AssignmentInCondition:
   Enabled: false
 


### PR DESCRIPTION
We have a `LetSetup` cop in our config. I think this should be `RSpec/LetSetup`, which makes me think maybe this was never working and is safe to remove?