### PR TITLE
Rubocop should ignore directives when calculating line length

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,7 @@ Metrics/BlockLength:
 
 Metrics/LineLength:
   Max: 120
+  IgnoreCopDirectives: true
   Exclude:
   - 'spec/spec_helper.rb'
   - 'spec/rails_helper.rb'


### PR DESCRIPTION
By default, rubocop includes rubocop directive comments when calculating line length. If you're using comments at the end of a line to disable an annoying rubocop directive, you can end up having your original directive disabled only to have the line length one suddenly trigger instead because with the directive comment your line is now too long.

Thankfully, since version 0.44.0 it's been possible to disable this behaviour. I've switched it on here so we can get it by default.