### PR TITLE
`Style/TrailingCommaInLiteral` no longer exists

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,5 +87,8 @@ Style/RegexpLiteral:
 Style/TrailingCommaInArguments:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
   Enabled: false


### PR DESCRIPTION
Replaced by `Style/TrailingCommaInHashLiteral` & `Style/TrailingCommaInArrayLiteral`